### PR TITLE
Avoid implicit fallthrough warnings

### DIFF
--- a/src/fasta_formatter/fasta_formatter.cpp
+++ b/src/fasta_formatter/fasta_formatter.cpp
@@ -103,6 +103,7 @@ void parse_command_line(int argc, char* argv[])
 		switch(opt) {
 		case 'h':
 			usage();
+			break;
 		
 		case 'i':
 			input_filename = optarg;


### PR DESCRIPTION
Newer gcc's warn/error on the implicit fallthough.

Add a break to make the intent clear.

This was also mentioned in #14.